### PR TITLE
FIXED parse/toString for Floating-point number with other Decimal sym…

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -183,13 +183,13 @@ namespace TinyJson
             if (type == typeof(float))
             {
                 float result;
-                float.TryParse(json, out result);
+                float.TryParse(json, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out result);
                 return result;
             }
             if (type == typeof(double))
             {
                 double result;
-                double.TryParse(json, out result);
+                double.TryParse(json, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out result);
                 return result;
             }
             if (type == typeof(bool))
@@ -301,7 +301,7 @@ namespace TinyJson
                 if (json.Contains("."))
                 {
                     double result;
-                    double.TryParse(json, out result);
+                    double.TryParse(json, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out result);
                     return result;
                 }
                 else

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -66,9 +66,17 @@ namespace TinyJson
                     }
                 stringBuilder.Append('"');
             }
-            else if (type == typeof(byte) || type == typeof(int) || type == typeof(float) || type == typeof(double))
+            else if (type == typeof(byte) || type == typeof(int))
             {
                 stringBuilder.Append(item.ToString());
+            }
+            else if (type == typeof(float))
+            {
+                stringBuilder.Append(((float)item).ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            else if (type == typeof(double))
+            {
+                stringBuilder.Append(((double)item).ToString(System.Globalization.CultureInfo.InvariantCulture));
             }
             else if (type == typeof(bool))
             {


### PR DESCRIPTION
Fixed for test: (Decimal Symbol ',')

Test Name:	TestArrayOfValues
Test FullName:	TinyJson.Test.TestParser.TestArrayOfValues
Test Source:	D:\Work\ARCH\JSON\test\TestParser.cs : line 41
Test Outcome:	Failed
Test Duration:	0:00:00,0051581

Result StackTrace:	
at TinyJson.Test.TestParser.ArrayTest[T](T[] expected, String json) in D:\Work\ARCH\JSON\test\TestParser.cs:line 36
   at TinyJson.Test.TestParser.TestArrayOfValues() in D:\Work\ARCH\JSON\test\TestParser.cs:line 46
Result Message:	CollectionAssert.AreEqual failed. (Element at index 0 do not match.)

Test Name:	TestListOfValues
Test FullName:	TinyJson.Test.TestParser.TestListOfValues
Test Source:	D:\Work\ARCH\JSON\test\TestParser.cs : line 59
Test Outcome:	Failed
Test Duration:	0:00:00,0047296

Result StackTrace:	
at TinyJson.Test.TestParser.ListTest[T](List`1 expected, String json) in D:\Work\ARCH\JSON\test\TestParser.cs:line 54
   at TinyJson.Test.TestParser.TestListOfValues() in D:\Work\ARCH\JSON\test\TestParser.cs:line 64
Result Message:	CollectionAssert.AreEqual failed. (Element at index 0 do not match.)

Test Name:	TestValues
Test FullName:	TinyJson.Test.TestParser.TestValues
Test Source:	D:\Work\ARCH\JSON\test\TestParser.cs : line 20
Test Outcome:	Failed
Test Duration:	0:00:00,0448326

Result StackTrace:	
at TinyJson.Test.TestParser.Test[T](T expected, String json) in D:\Work\ARCH\JSON\test\TestParser.cs:line 15
   at TinyJson.Test.TestParser.TestValues() in D:\Work\ARCH\JSON\test\TestParser.cs:line 22
Result Message:	Assert.AreEqual failed. Expected:<12,532>. Actual:<12532>.

