### PR TITLE
change escapes conforming to standard

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -39,7 +39,7 @@ namespace TinyJson
             for (int i = 0; i < json.Length; i++)
             {
                 char c = json[i];
-                if (c == '\"')
+                if (c == '"')
                 {
                     i = AppendUntilStringEnd(true, i, json);
                     continue;
@@ -66,7 +66,7 @@ namespace TinyJson
                     stringBuilder.Append(json[i + 1]);
                     i++;//Skip next character as it is escaped
                 }
-                else if (json[i] == '\"')
+                else if (json[i] == '"')
                 {
                     stringBuilder.Append(json[i]);
                     return i;
@@ -98,7 +98,7 @@ namespace TinyJson
                     case '}':
                         parseDepth--;
                         break;
-                    case '\"':
+                    case '"':
                         i = AppendUntilStringEnd(true, i, json);
                         continue;
                     case ',':
@@ -131,40 +131,25 @@ namespace TinyJson
                 {
                     if (json[i] == '\\' && i + 1 < json.Length - 1)
                     {
-                        switch (json[i+1])
+                        int j = "\"\\nrtbf/".IndexOf(json[i + 1]);
+                        if (j >= 0)
                         {
-                            case '"':
-                                stringBuilder.Append('"');
-                                break;
-                            case '\\':
-                                stringBuilder.Append("\\");
-                                break;
-                            case 'b':
-                                stringBuilder.Append("\b");
-                                break;
-                            case 'f':
-                                stringBuilder.Append("\f");
-                                break;
-                            case 't':
-                                stringBuilder.Append("\t");
-                                break;
-                            case 'n':
-                                stringBuilder.Append("\n");
-                                break;
-                            case 'r':
-                                stringBuilder.Append("\r");
-                                break;
-                            case '0':
-                                stringBuilder.Append("\0");
-                                break;
-                            default:
-                                stringBuilder.Append(json[i]);
-                                break;
+                            stringBuilder.Append("\"\\\n\r\t\b\f/"[j]);
+                            ++i;
+                            continue;
                         }
-                        ++i;
+                        if (json[i + 1] == 'u' && i + 5 < json.Length - 1)
+                        {
+                            UInt32 c = 0;
+                            if (UInt32.TryParse(json.Substring(i + 2, 4), System.Globalization.NumberStyles.AllowHexSpecifier, null, out c))
+                            {
+                                stringBuilder.Append((char)c);
+                                i += 5;
+                                continue;
+                            }
+                        }
                     }
-                    else
-                        stringBuilder.Append(json[i]);
+                    stringBuilder.Append(json[i]);
                 }
                 return stringBuilder.ToString();
             }
@@ -291,7 +276,7 @@ namespace TinyJson
                     finalList.Add(ParseAnonymousValue(items[i]));
                 return finalList;
             }
-            if (json[0] == '\"' && json[json.Length - 1] == '\"')
+            if (json[0] == '"' && json[json.Length - 1] == '"')
             {
                 string str = json.Substring(1, json.Length - 2);
                 return str.Replace("\\", string.Empty);

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -34,36 +34,17 @@ namespace TinyJson
                 stringBuilder.Append('"');
                 string str = (string)item;
                 for (int i = 0; i<str.Length; ++i)
-                    switch (str[i])
+                    if (str[i] < ' ' || str[i] == '"' || str[i] == '\\')
                     {
-                        case '\\':
-                            stringBuilder.Append("\\\\");
-                            break;
-                        case '\"':
-                            stringBuilder.Append("\\\"");
-                            break;
-                        case '\b':
-                            stringBuilder.Append("\\b");
-                            break;
-                        case '\f':
-                            stringBuilder.Append("\\f");
-                            break;
-                        case '\t':
-                            stringBuilder.Append("\\t");
-                            break;
-                        case '\n':
-                            stringBuilder.Append("\\n");
-                            break;
-                        case '\r':
-                            stringBuilder.Append("\\r");
-                            break;
-                        case '\0':
-                            stringBuilder.Append("\\0");
-                            break;
-                        default:
-                            stringBuilder.Append(str[i]);
-                            break;
+                        stringBuilder.Append('\\');
+                        int j = "\"\\\n\r\t\b\f".IndexOf(str[i]);
+                        if (j >= 0)
+                            stringBuilder.Append("\"\\nrtbf"[j]);
+                        else
+                            stringBuilder.AppendFormat("u{0:X4}", (UInt32)str[i]);
                     }
+                    else
+                        stringBuilder.Append(str[i]);
                 stringBuilder.Append('"');
             }
             else if (type == typeof(byte) || type == typeof(int))

--- a/test/TestParser.cs
+++ b/test/TestParser.cs
@@ -259,8 +259,8 @@ namespace TinyJson.Test
         [TestMethod]
         public void TestEscaping()
         {
-            var orig = new Dictionary<string,string>{{"hello", "world\n \" \\ \b \r \0"}};
-            var parsed = "{\"hello\":\"world\\n \\\" \\\\ \\b \\r \\0\"}".FromJson<Dictionary<string,string>>();
+            var orig = new Dictionary<string,string>{{"hello", "world\n \" \\ \b \r \\0\u263A" } };
+            var parsed = "{\"hello\":\"world\\n \\\" \\\\ \\b \\r \\0\\u263a\"}".FromJson<Dictionary<string,string>>();
             Assert.AreEqual(orig["hello"], parsed["hello"]);
         }
     }

--- a/test/TestWriter.cs
+++ b/test/TestWriter.cs
@@ -62,8 +62,8 @@ namespace TinyJson.Test
         [TestMethod]
         public void TestEscaping()
         {
-            Assert.AreEqual("{\"hello\":\"world\\n \\\\ \\\" \\b \\r \\0\"}", new Dictionary<string,string>{
-                {"hello", "world\n \\ \" \b \r \0"}
+            Assert.AreEqual("{\"hello\":\"world\\n \\\\ \\\" \\b \\r \\u0000\u263A\"}", new Dictionary<string,string>{
+                {"hello", "world\n \\ \" \b \r \0\u263A"}
             }.ToJson());
         }
     }


### PR DESCRIPTION
Hi Alex,

Compared to the standard \0 is too much and \u missing. This pull changes it.

See https://www.json.org/ and https://tools.ietf.org/html/rfc7159 .

Kind regards,
    Gero