### PR TITLE
Fix multithreading

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -27,10 +27,41 @@ namespace TinyJson
     // - Parsing of abstract classes or interfaces is NOT supported and will throw an exception.
     public static class JSONParser
     {
-        static Stack<List<string>> splitArrayPool = new Stack<List<string>>();
-        static StringBuilder stringBuilder = new StringBuilder();
-        static readonly Dictionary<Type, Dictionary<string, FieldInfo>> fieldInfoCache = new Dictionary<Type, Dictionary<string, FieldInfo>>();
-        static readonly Dictionary<Type, Dictionary<string, PropertyInfo>> propertyInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
+        [ThreadStatic]
+        static Stack<List<string>> _splitArrayPool;
+        static Stack<List<string>> splitArrayPool {
+            get {
+                if (null == _splitArrayPool) _splitArrayPool = new Stack<List<string>>();
+                return _splitArrayPool;
+            }
+        }
+
+        [ThreadStatic]
+        static StringBuilder _stringBuilder;
+        static StringBuilder stringBuilder {
+            get {
+                if (null == _stringBuilder) _stringBuilder = new StringBuilder();
+                return _stringBuilder;
+            }
+        }
+
+        [ThreadStatic]
+        static Dictionary<Type, Dictionary<string, FieldInfo>> _fieldInfoCache;
+        static Dictionary<Type, Dictionary<string, FieldInfo>> fieldInfoCache {
+            get {
+                if (null == _fieldInfoCache) _fieldInfoCache = new Dictionary<Type, Dictionary<string, FieldInfo>>();
+                return _fieldInfoCache;
+            }
+        }
+
+        [ThreadStatic]
+        static Dictionary<Type, Dictionary<string, PropertyInfo>> _propertyInfoCache;
+        static Dictionary<Type, Dictionary<string, PropertyInfo>> propertyInfoCache {
+            get {
+                if (null == _propertyInfoCache) _propertyInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
+                return _propertyInfoCache;
+            }
+        }
 
         public static T FromJson<T>(this string json)
         {

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -27,44 +27,19 @@ namespace TinyJson
     // - Parsing of abstract classes or interfaces is NOT supported and will throw an exception.
     public static class JSONParser
     {
-        [ThreadStatic]
-        static Stack<List<string>> _splitArrayPool;
-        static Stack<List<string>> splitArrayPool {
-            get {
-                if (null == _splitArrayPool) _splitArrayPool = new Stack<List<string>>();
-                return _splitArrayPool;
-            }
-        }
-
-        [ThreadStatic]
-        static StringBuilder _stringBuilder;
-        static StringBuilder stringBuilder {
-            get {
-                if (null == _stringBuilder) _stringBuilder = new StringBuilder();
-                return _stringBuilder;
-            }
-        }
-
-        [ThreadStatic]
-        static Dictionary<Type, Dictionary<string, FieldInfo>> _fieldInfoCache;
-        static Dictionary<Type, Dictionary<string, FieldInfo>> fieldInfoCache {
-            get {
-                if (null == _fieldInfoCache) _fieldInfoCache = new Dictionary<Type, Dictionary<string, FieldInfo>>();
-                return _fieldInfoCache;
-            }
-        }
-
-        [ThreadStatic]
-        static Dictionary<Type, Dictionary<string, PropertyInfo>> _propertyInfoCache;
-        static Dictionary<Type, Dictionary<string, PropertyInfo>> propertyInfoCache {
-            get {
-                if (null == _propertyInfoCache) _propertyInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
-                return _propertyInfoCache;
-            }
-        }
+        [ThreadStatic] static Stack<List<string>> splitArrayPool;
+        [ThreadStatic] static StringBuilder stringBuilder;
+        [ThreadStatic] static Dictionary<Type, Dictionary<string, FieldInfo>> fieldInfoCache;
+        [ThreadStatic] static Dictionary<Type, Dictionary<string, PropertyInfo>> propertyInfoCache;
 
         public static T FromJson<T>(this string json)
         {
+            // Initialize, if needed, the ThreadStatic variables
+            if (null == propertyInfoCache) propertyInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
+            if (null == fieldInfoCache) fieldInfoCache = new Dictionary<Type, Dictionary<string, FieldInfo>>();
+            if (null == stringBuilder) stringBuilder = new StringBuilder();
+            if (null == splitArrayPool) splitArrayPool = new Stack<List<string>>();
+
             //Remove all whitespace not within strings to make parsing simpler
             stringBuilder.Length = 0;
             for (int i = 0; i < json.Length; i++)

--- a/test/TestParser.cs
+++ b/test/TestParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinyJson;
 
@@ -263,5 +264,32 @@ namespace TinyJson.Test
             var parsed = "{\"hello\":\"world\\n \\\" \\\\ \\b \\r \\0\\u263a\"}".FromJson<Dictionary<string,string>>();
             Assert.AreEqual(orig["hello"], parsed["hello"]);
         }
+
+		[TestMethod]
+		public void TestMultithread() {
+			// Lots of threads
+			for (int i = 0; i < 100; i++) {
+				new Thread(() => {
+					// Each threads has enough work to potentially hit a race condition
+					for (int j = 0; j < 10000; j++) {
+						TestValues();
+						TestArrayOfValues();
+						TestListOfValues();
+						TestRecursiveLists();
+						TestRecursiveArrays();
+						TestDictionary();
+						TestRecursiveDictionary();
+						TestSimpleObject();
+						TestSimpleStruct();
+						TestListOfStructs();
+						TestDeepObject();
+						CorruptionTest();
+						DynamicParserTest();
+						TestNastyStruct();
+						TestEscaping();
+					}
+				}).Start();
+			}
+		}
     }
 }


### PR DESCRIPTION
There was a problem with the static variables used for caching in a multithreaded sceneario: having multiple threads parsing at the same time would trash the cached static variables.
The first commit has a test that will fail with the previous implementation while the second commit fixes the problem by using the attribute [ThreadStatic] and properties (because a ThreadStatic variable can't be initialized directly as it was before).
So now it is thread safe :smiley: 