### PR TITLE
IgnoreDataMember and DataMember attribute support.

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -310,6 +310,14 @@ namespace TinyJson
             return null;
         }
 
+        static string GetMemberName(MemberInfo member)
+        {
+            DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
+            if (dataMemberAttribute != null && dataMemberAttribute.IsNameSetExplicitly)
+                return dataMemberAttribute.Name;
+            return member.Name;
+        }
+
         static object ParseObject(Type type, string json)
         {
             object instance = FormatterServices.GetUninitializedObject(type);
@@ -323,12 +331,12 @@ namespace TinyJson
             Dictionary<string, PropertyInfo> nameToProperty;
             if (!fieldInfoCache.TryGetValue(type, out nameToField))
             {
-                nameToField = type.GetFields().Where(field => field.IsPublic).ToDictionary(field => field.Name);
+                nameToField = type.GetFields().Where(field => field.IsPublic && field.GetCustomAttribute<IgnoreDataMemberAttribute>() == null).ToDictionary(GetMemberName);
                 fieldInfoCache.Add(type, nameToField);
             }
             if (!propertyInfoCache.TryGetValue(type, out nameToProperty))
             {
-                nameToProperty = type.GetProperties().ToDictionary(p => p.Name);
+                nameToProperty = type.GetProperties().Where(property => property.GetCustomAttribute<IgnoreDataMemberAttribute>() == null).ToDictionary(GetMemberName);
                 propertyInfoCache.Add(type, nameToProperty);
             }
 

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace TinyJson
@@ -113,7 +114,7 @@ namespace TinyJson
                 FieldInfo[] fieldInfos = type.GetFields();
                 for (int i = 0; i < fieldInfos.Length; i++)
                 {
-                    if (fieldInfos[i].IsPublic && !fieldInfos[i].IsStatic)
+                    if (fieldInfos[i].IsPublic && !fieldInfos[i].IsStatic && fieldInfos[i].GetCustomAttribute<IgnoreDataMemberAttribute>() == null)
                     {
                         object value = fieldInfos[i].GetValue(item);
                         if (value != null)
@@ -123,7 +124,7 @@ namespace TinyJson
                             else
                                 stringBuilder.Append(',');
                             stringBuilder.Append('\"');
-                            stringBuilder.Append(fieldInfos[i].Name);
+                            stringBuilder.Append(GetMemberName(fieldInfos[i]));
                             stringBuilder.Append("\":");
                             AppendValue(stringBuilder, value);
                         }
@@ -132,7 +133,7 @@ namespace TinyJson
                 PropertyInfo[] propertyInfo = type.GetProperties();
                 for (int i = 0; i<propertyInfo.Length; i++)
                 {
-                    if (propertyInfo[i].CanRead)
+                    if (propertyInfo[i].CanRead && propertyInfo[i].GetCustomAttribute<IgnoreDataMemberAttribute>() == null)
                     {
                         object value = propertyInfo[i].GetValue(item, null);
                         if (value != null)
@@ -142,7 +143,7 @@ namespace TinyJson
                             else
                                 stringBuilder.Append(',');
                             stringBuilder.Append('\"');
-                            stringBuilder.Append(propertyInfo[i].Name);
+                            stringBuilder.Append(GetMemberName(propertyInfo[i]));
                             stringBuilder.Append("\":");
                             AppendValue(stringBuilder, value);
                         }
@@ -151,6 +152,14 @@ namespace TinyJson
 
                 stringBuilder.Append('}');
             }
+        }
+
+        static string GetMemberName(MemberInfo member)
+        {
+            DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
+            if (dataMemberAttribute != null && dataMemberAttribute.IsNameSetExplicitly)
+                return dataMemberAttribute.Name;
+            return member.Name;
         }
     }
 }

--- a/test/TestParser.cs
+++ b/test/TestParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -291,5 +292,50 @@ namespace TinyJson.Test
 				}).Start();
 			}
 		}
+
+        class IgnoreDataMemberObject
+        {
+            public int A;
+            [IgnoreDataMember]
+            public int B;
+
+            public int C { get; set; }
+            [IgnoreDataMember]
+            public int D { get; set; }
+        }
+
+        [TestMethod]
+        public void TestIgnoreDataMember()
+        {
+            IgnoreDataMemberObject value = "{\"A\":123,\"B\":456,\"Ignored\":10,\"C\":789,\"D\":14}".FromJson<IgnoreDataMemberObject>();
+            Assert.IsNotNull(value);
+            Assert.AreEqual(123, value.A);
+            Assert.AreEqual(0, value.B);
+            Assert.AreEqual(789, value.C);
+            Assert.AreEqual(0, value.D);
+        }
+
+        class DataMemberObject
+        {
+            [DataMember(Name = "a")]
+            public int A;
+            [DataMember()]
+            public int B;
+
+            [DataMember(Name = "c")]
+            public int C { get; set; }
+            public int D { get; set; }
+        }
+
+        [TestMethod]
+        public void TestDataMemberObject()
+        {
+            DataMemberObject value = "{\"a\":123,\"B\":456,\"c\":789,\"D\":14}".FromJson<DataMemberObject>();
+            Assert.IsNotNull(value);
+            Assert.AreEqual(123, value.A);
+            Assert.AreEqual(456, value.B);
+            Assert.AreEqual(789, value.C);
+            Assert.AreEqual(14, value.D);
+        }
     }
 }

--- a/test/TestWriter.cs
+++ b/test/TestWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinyJson;
 
@@ -65,6 +66,39 @@ namespace TinyJson.Test
             Assert.AreEqual("{\"hello\":\"world\\n \\\\ \\\" \\b \\r \\u0000\u263A\"}", new Dictionary<string,string>{
                 {"hello", "world\n \\ \" \b \r \0\u263A"}
             }.ToJson());
+        }
+
+        class IgnoreDataMemberObject
+        {
+            [IgnoreDataMember]
+            public int A;
+            public int B;
+            [IgnoreDataMember]
+            public int C { get; set; }
+            public int D { get; set; }
+        }
+
+        [TestMethod]
+        public void TestIgnoreDataMemberObject()
+        {
+            Assert.AreEqual("{\"B\":20,\"D\":40}", new IgnoreDataMemberObject { A = 10, B = 20, C = 30, D = 40 }.ToJson());
+        }
+
+        class DataMemberObject
+        {
+            [DataMember(Name = "a")]
+            public int A;
+            [DataMember()]
+            public int B;
+            [DataMember(Name = "c")]
+            public int C { get; set; }
+            public int D { get; set; }
+        }
+
+        [TestMethod]
+        public void TestDataMemberObject()
+        {
+            Assert.AreEqual("{\"a\":10,\"B\":20,\"c\":30,\"D\":40}", new DataMemberObject { A = 10, B = 20, C = 30, D = 40 }.ToJson());
         }
     }
 }


### PR DESCRIPTION
Added support for IgnoreDataMember attribute and renaming through DataMember attribute. Also added Unit Tests.

This will allow you to serialize to something named differently than your C# classes. [DataMember(Name = "myOwnName")] is useful when dealing with RPC-services where server use a different naming standard. 

[IgnoreDataMember] makes the parser and writer ignore the member as if it didn't exist.