### PR TITLE
Removed all LINQ dependencies

### DIFF
--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
@@ -82,7 +81,7 @@ namespace TinyJson
             else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {
                 Type keyType = type.GetGenericArguments()[0];
-                
+
                 //Refuse to output dictionary keys that aren't of type string
                 if (keyType != typeof(string))
                 {
@@ -111,42 +110,42 @@ namespace TinyJson
                 stringBuilder.Append('{');
 
                 bool isFirst = true;
-                FieldInfo[] fieldInfos = type.GetFields();
+                FieldInfo[] fieldInfos = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i < fieldInfos.Length; i++)
                 {
-                    if (fieldInfos[i].IsPublic && !fieldInfos[i].IsStatic && fieldInfos[i].GetCustomAttribute<IgnoreDataMemberAttribute>() == null)
+                    if (fieldInfos[i].GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+                        continue;
+
+                    object value = fieldInfos[i].GetValue(item);
+                    if (value != null)
                     {
-                        object value = fieldInfos[i].GetValue(item);
-                        if (value != null)
-                        {
-                            if (isFirst)
-                                isFirst = false;
-                            else
-                                stringBuilder.Append(',');
-                            stringBuilder.Append('\"');
-                            stringBuilder.Append(GetMemberName(fieldInfos[i]));
-                            stringBuilder.Append("\":");
-                            AppendValue(stringBuilder, value);
-                        }
+                        if (isFirst)
+                            isFirst = false;
+                        else
+                            stringBuilder.Append(',');
+                        stringBuilder.Append('\"');
+                        stringBuilder.Append(GetMemberName(fieldInfos[i]));
+                        stringBuilder.Append("\":");
+                        AppendValue(stringBuilder, value);
                     }
                 }
-                PropertyInfo[] propertyInfo = type.GetProperties();
+                PropertyInfo[] propertyInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i<propertyInfo.Length; i++)
                 {
-                    if (propertyInfo[i].CanRead && propertyInfo[i].GetCustomAttribute<IgnoreDataMemberAttribute>() == null)
+                    if (!propertyInfo[i].CanRead || propertyInfo[i].GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+                        continue;
+
+                    object value = propertyInfo[i].GetValue(item, null);
+                    if (value != null)
                     {
-                        object value = propertyInfo[i].GetValue(item, null);
-                        if (value != null)
-                        {
-                            if (isFirst)
-                                isFirst = false;
-                            else
-                                stringBuilder.Append(',');
-                            stringBuilder.Append('\"');
-                            stringBuilder.Append(GetMemberName(propertyInfo[i]));
-                            stringBuilder.Append("\":");
-                            AppendValue(stringBuilder, value);
-                        }
+                        if (isFirst)
+                            isFirst = false;
+                        else
+                            stringBuilder.Append(',');
+                        stringBuilder.Append('\"');
+                        stringBuilder.Append(GetMemberName(propertyInfo[i]));
+                        stringBuilder.Append("\":");
+                        AppendValue(stringBuilder, value);
                     }
                 }
 

--- a/test/TestWriter.cs
+++ b/test/TestWriter.cs
@@ -30,6 +30,13 @@ namespace TinyJson.Test
             public SimpleObject A;
             public List<int> B;
             public string C { get; set; }
+
+            // Should not serialize
+            private int D = 333;
+            public static int E = 555;
+            internal int F = 777;
+            protected int G = 999;
+            public const int H = 111;
         }
 
         struct SimpleStruct
@@ -37,11 +44,17 @@ namespace TinyJson.Test
             public SimpleObject A;
         }
 
+        class InheritedObject : SimpleObject
+        {
+            public int X;
+        }
+
         [TestMethod]
         public void TestObjects()
         {
             Assert.AreEqual("{\"A\":{},\"B\":[1,2,3],\"C\":\"Test\"}", new SimpleObject { A = new SimpleObject(), B = new List<int> { 1, 2, 3 }, C = "Test" }.ToJson());
             Assert.AreEqual("{\"A\":{\"A\":{},\"B\":[1,2,3],\"C\":\"Test\"}}", new SimpleStruct { A = new SimpleObject { A = new SimpleObject(), B = new List<int> { 1, 2, 3 }, C = "Test" } }.ToJson());
+            Assert.AreEqual("{\"X\":9,\"A\":{},\"B\":[1,2,3],\"C\":\"Test\"}", new InheritedObject { A = new SimpleObject(), B = new List<int> { 1, 2, 3 }, C = "Test", X = 9 }.ToJson());
         }
 
         public struct NastyStruct


### PR DESCRIPTION
Removed the LINQ dependencies in the parser ("Where" and "ToDictionary"). It also now uses more explicit BindingFlags when getting fields and properties to only get public instance fields, as well as flattening out the hierarchy to allow serialization of inherited classes.