### PR TITLE
Added enum and flagged enum support.

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -175,11 +175,16 @@ namespace TinyJson
             }
             if (type.IsEnum)
             {
-                object result;
+                int result = 0;
                 if (json[0] == '"')
                     json = json.Substring(1, json.Length - 2);
-                if (!Enum.TryParse(type, json, true, out result))
-                    result = 0;
+                try
+                {
+                    result = (int)Enum.Parse(type, json, true);
+                }
+                catch
+                {
+                }
                 return result;
             }
             if (type.IsArray)

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -179,7 +179,7 @@ namespace TinyJson
                     json = json.Substring(1, json.Length - 2);
                 try
                 {
-                    return Enum.Parse(type, json, true);
+                    return Enum.Parse(type, json, false);
                 }
                 catch
                 {

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -175,17 +175,16 @@ namespace TinyJson
             }
             if (type.IsEnum)
             {
-                int result = 0;
                 if (json[0] == '"')
                     json = json.Substring(1, json.Length - 2);
                 try
                 {
-                    result = (int)Enum.Parse(type, json, true);
+                    return Enum.Parse(type, json, true);
                 }
                 catch
                 {
+                    return 0;
                 }
-                return result;
             }
             if (type.IsArray)
             {

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -173,6 +173,15 @@ namespace TinyJson
             {
                 return null;
             }
+            if (type.IsEnum)
+            {
+                object result;
+                if (json[0] == '"')
+                    json = json.Substring(1, json.Length - 2);
+                if (!Enum.TryParse(type, json, true, out result))
+                    result = 0;
+                return result;
+            }
             if (type.IsArray)
             {
                 Type arrayType = type.GetElementType();

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -63,6 +63,29 @@ namespace TinyJson
             {
                 stringBuilder.Append(((bool)item) ? "true" : "false");
             }
+            else if (type.IsEnum)
+            {
+                bool isEnumDefined = type.IsEnumDefined(item);
+                if (!isEnumDefined && type.IsDefined(typeof(FlagsAttribute), false))
+                {
+                    // Check if all the flags are defined
+                    int itemValue = (int)item;
+                    var enumValues = (int[])Enum.GetValues(type);
+                    for (int i = 0; i < enumValues.Length; i++)
+                        itemValue &= ~enumValues[i];
+
+                    isEnumDefined = (itemValue == 0);
+                }
+
+                if (isEnumDefined)
+                {
+                    stringBuilder.Append('"');
+                    stringBuilder.Append(item.ToString());
+                    stringBuilder.Append('"');
+                }
+                else
+                    stringBuilder.Append((int)item);
+            }
             else if (item is IList)
             {
                 stringBuilder.Append('[');

--- a/test/TestParser.cs
+++ b/test/TestParser.cs
@@ -11,6 +11,24 @@ namespace TinyJson.Test
     [TestClass]
     public class TestParser
     {
+        public enum Color
+        {
+            Red,
+            Green,
+            Blue,
+            Yellow
+        }
+
+        [Flags]
+        public enum Style
+        {
+            None = 0,
+            Bold = 1,
+            Italic = 2,
+            Underline = 4,
+            Strikethrough = 8
+        }
+
         static void Test<T>(T expected, string json)
         {
             T value = json.FromJson<T>();
@@ -33,6 +51,11 @@ namespace TinyJson.Test
             Test(true, "true");
             Test(false, "false");
             Test<object>(null, "sfdoijsdfoij");
+            Test(Color.Green, "\"Green\"");
+            Test(Color.Blue, "2");
+            Test(Color.Red, "\"sfdoijsdfoij\"");
+            Test(Style.Bold | Style.Italic, "\"Bold, Italic\"");
+            Test(Style.Bold | Style.Italic, "3");
         }
 
         static void ArrayTest<T>(T[] expected, string json)
@@ -339,6 +362,31 @@ namespace TinyJson.Test
             Assert.AreEqual(456, value.B);
             Assert.AreEqual(789, value.C);
             Assert.AreEqual(14, value.D);
+        }
+        
+        public class EnumClass
+        {
+            public Color Colors;
+            public Style Style;
+        }
+
+        [TestMethod]
+        public void TestEnumMember()
+        {
+            EnumClass value = "{\"Colors\":\"Green\",\"Style\":\"Bold, Underline\"}".FromJson<EnumClass>();
+            Assert.IsNotNull(value);
+            Assert.AreEqual(Color.Green, value.Colors);
+            Assert.AreEqual(Style.Bold | Style.Underline, value.Style);
+
+            value = "{\"Colors\":3,\"Style\":10}".FromJson<EnumClass>();
+            Assert.IsNotNull(value);
+            Assert.AreEqual(Color.Yellow, value.Colors);
+            Assert.AreEqual(Style.Italic | Style.Strikethrough, value.Style);
+
+            value = "{\"Colors\":\"sfdoijsdfoij\",\"Style\":\"sfdoijsdfoij\"}".FromJson<EnumClass>();
+            Assert.IsNotNull(value);
+            Assert.AreEqual(Color.Red, value.Colors);
+            Assert.AreEqual(Style.None, value.Style);
         }
     }
 }

--- a/test/TestWriter.cs
+++ b/test/TestWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinyJson;
@@ -8,6 +9,23 @@ namespace TinyJson.Test
     [TestClass]
     public class TestWriter
     {
+        public enum Color
+        {
+            Red,
+            Green,
+            Blue,
+            Yellow
+        }
+
+        [Flags]
+        public enum Style
+        {
+            Bold = 1,
+            Italic = 2,
+            Underline = 4,
+            Strikethrough = 8
+        }
+
         [TestMethod]
         public void TestValues()
         {
@@ -16,6 +34,12 @@ namespace TinyJson.Test
             Assert.AreEqual("false", false.ToJson());
             Assert.AreEqual("[1,2,3]", new int[] { 1, 2, 3 }.ToJson());
             Assert.AreEqual("[1,2,3]", new List<int> { 1, 2, 3 }.ToJson());
+            Assert.AreEqual("\"Green\"", Color.Green.ToJson());
+            Assert.AreEqual("\"Green\"", ((Color)1).ToJson());
+            Assert.AreEqual("10", ((Color)10).ToJson());
+            Assert.AreEqual("\"Bold\"", Style.Bold.ToJson());
+            Assert.AreEqual("\"Bold, Italic\"", (Style.Bold | Style.Italic).ToJson());
+            Assert.AreEqual("19", (Style.Bold | Style.Italic | (Style)16).ToJson());
         }
 
         [TestMethod]
@@ -112,6 +136,22 @@ namespace TinyJson.Test
         public void TestDataMemberObject()
         {
             Assert.AreEqual("{\"a\":10,\"B\":20,\"c\":30,\"D\":40}", new DataMemberObject { A = 10, B = 20, C = 30, D = 40 }.ToJson());
+        }
+
+        public class EnumClass
+        {
+            public Color Colors;
+            public Style Style;
+        }
+
+        [TestMethod]
+        public void TestEnumMember()
+        {
+            Assert.AreEqual("{\"Colors\":\"Green\",\"Style\":\"Bold\"}", new EnumClass { Colors = Color.Green, Style = Style.Bold }.ToJson());
+            Assert.AreEqual("{\"Colors\":\"Green\",\"Style\":\"Bold, Underline\"}", new EnumClass { Colors = Color.Green, Style = Style.Bold | Style.Underline }.ToJson());
+            Assert.AreEqual("{\"Colors\":\"Blue\",\"Style\":\"Italic, Underline\"}", new EnumClass { Colors = (Color)2, Style = (Style)6 }.ToJson());
+            Assert.AreEqual("{\"Colors\":\"Blue\",\"Style\":\"Underline\"}", new EnumClass { Colors = (Color)2, Style = (Style)4 }.ToJson());
+            Assert.AreEqual("{\"Colors\":10,\"Style\":17}", new EnumClass { Colors = (Color)10, Style = (Style)17 }.ToJson());
         }
     }
 }


### PR DESCRIPTION
**Writer**
The writer tries to write a string of the enum name if possible. If not defined it will write the numerical value.

For flags (enums marked with the [Flags] attribute) it will try to write a string with the names of the enum, comma delimited. If not all bits exists as a named flag it will write the numerical value.

**Parser**
The parser will accept string names of both flags and singular values. It will also accept numerical values as input.

**Tests**
Unit tests for testing both valid and unvalid data added.