### PR TITLE
Optimized allocations by checking for attribute existence with IsDefined

### DIFF
--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -131,7 +131,7 @@ namespace TinyJson
             {
                 if (json.Length <= 2)
                     return string.Empty;
-                StringBuilder stringBuilder = new StringBuilder();
+                StringBuilder parseStringBuilder = new StringBuilder(json.Length);
                 for (int i = 1; i<json.Length-1; ++i)
                 {
                     if (json[i] == '\\' && i + 1 < json.Length - 1)
@@ -139,7 +139,7 @@ namespace TinyJson
                         int j = "\"\\nrtbf/".IndexOf(json[i + 1]);
                         if (j >= 0)
                         {
-                            stringBuilder.Append("\"\\\n\r\t\b\f/"[j]);
+                            parseStringBuilder.Append("\"\\\n\r\t\b\f/"[j]);
                             ++i;
                             continue;
                         }
@@ -148,15 +148,15 @@ namespace TinyJson
                             UInt32 c = 0;
                             if (UInt32.TryParse(json.Substring(i + 2, 4), System.Globalization.NumberStyles.AllowHexSpecifier, null, out c))
                             {
-                                stringBuilder.Append((char)c);
+                                parseStringBuilder.Append((char)c);
                                 i += 5;
                                 continue;
                             }
                         }
                     }
-                    stringBuilder.Append(json[i]);
+                    parseStringBuilder.Append(json[i]);
                 }
-                return stringBuilder.ToString();
+                return parseStringBuilder.ToString();
             }
             if (type.IsPrimitive)
             {
@@ -314,15 +314,13 @@ namespace TinyJson
                 if (member.IsDefined(typeof(IgnoreDataMemberAttribute), false))
                     continue;
 
-                string name;
-
+                string name = member.Name;
                 if (member.IsDefined(typeof(IgnoreDataMemberAttribute), false))
                 {
                     DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
-                    name = dataMemberAttribute.IsNameSetExplicitly ? dataMemberAttribute.Name : member.Name;
+                    if (dataMemberAttribute.IsNameSetExplicitly)
+                        name = dataMemberAttribute.Name;
                 }
-                else
-                    name = member.Name;
 
                 nameToMember.Add(name, member);
             }

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -311,13 +311,16 @@ namespace TinyJson
             for (int i = 0; i < members.Length; i++)
             {
                 T member = members[i];
-                if (member.GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+                if (member.IsDefined(typeof(IgnoreDataMemberAttribute), false))
                     continue;
 
                 string name;
-                DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
-                if (dataMemberAttribute != null && dataMemberAttribute.IsNameSetExplicitly)
-                    name = dataMemberAttribute.Name;
+
+                if (member.IsDefined(typeof(IgnoreDataMemberAttribute), false))
+                {
+                    DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
+                    name = dataMemberAttribute.IsNameSetExplicitly ? dataMemberAttribute.Name : member.Name;
+                }
                 else
                     name = member.Name;
 

--- a/src/JSONParser.cs
+++ b/src/JSONParser.cs
@@ -317,7 +317,7 @@ namespace TinyJson
                 string name = member.Name;
                 if (member.IsDefined(typeof(DataMemberAttribute), true))
                 {
-                    DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>(true);
+                    DataMemberAttribute dataMemberAttribute = (DataMemberAttribute)Attribute.GetCustomAttribute(member, typeof(DataMemberAttribute), true);
                     if (!string.IsNullOrEmpty(dataMemberAttribute.Name))
                         name = dataMemberAttribute.Name;
                 }

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -163,7 +163,7 @@ namespace TinyJson
         {
             if (member.IsDefined(typeof(DataMemberAttribute), true))
             {
-                DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>(true);
+                DataMemberAttribute dataMemberAttribute = (DataMemberAttribute)Attribute.GetCustomAttribute(member, typeof(DataMemberAttribute), true);
                 if (!string.IsNullOrEmpty(dataMemberAttribute.Name))
                     return dataMemberAttribute.Name;
             }

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -136,7 +136,7 @@ namespace TinyJson
                 FieldInfo[] fieldInfos = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i < fieldInfos.Length; i++)
                 {
-                    if (fieldInfos[i].GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+                    if (fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute)))
                         continue;
 
                     object value = fieldInfos[i].GetValue(item);
@@ -155,7 +155,7 @@ namespace TinyJson
                 PropertyInfo[] propertyInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i<propertyInfo.Length; i++)
                 {
-                    if (!propertyInfo[i].CanRead || propertyInfo[i].GetCustomAttribute<IgnoreDataMemberAttribute>() != null)
+                    if (!propertyInfo[i].CanRead || fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute)))
                         continue;
 
                     object value = propertyInfo[i].GetValue(item, null);
@@ -178,9 +178,13 @@ namespace TinyJson
 
         static string GetMemberName(MemberInfo member)
         {
-            DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
-            if (dataMemberAttribute != null && dataMemberAttribute.IsNameSetExplicitly)
-                return dataMemberAttribute.Name;
+            if (member.IsDefined(typeof(DataMemberAttribute)))
+            {
+                DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
+                if (dataMemberAttribute.IsNameSetExplicitly)
+                    return dataMemberAttribute.Name;
+            }
+
             return member.Name;
         }
     }

--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -136,7 +136,7 @@ namespace TinyJson
                 FieldInfo[] fieldInfos = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i < fieldInfos.Length; i++)
                 {
-                    if (fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute)))
+                    if (fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute), false))
                         continue;
 
                     object value = fieldInfos[i].GetValue(item);
@@ -155,7 +155,7 @@ namespace TinyJson
                 PropertyInfo[] propertyInfo = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                 for (int i = 0; i<propertyInfo.Length; i++)
                 {
-                    if (!propertyInfo[i].CanRead || fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute)))
+                    if (!propertyInfo[i].CanRead || fieldInfos[i].IsDefined(typeof(IgnoreDataMemberAttribute), false))
                         continue;
 
                     object value = propertyInfo[i].GetValue(item, null);
@@ -178,7 +178,7 @@ namespace TinyJson
 
         static string GetMemberName(MemberInfo member)
         {
-            if (member.IsDefined(typeof(DataMemberAttribute)))
+            if (member.IsDefined(typeof(DataMemberAttribute), false))
             {
                 DataMemberAttribute dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>();
                 if (dataMemberAttribute.IsNameSetExplicitly)

--- a/test/TestParser.cs
+++ b/test/TestParser.cs
@@ -58,6 +58,7 @@ namespace TinyJson.Test
             Test(Style.Bold | Style.Italic, "\"Bold, Italic\"");
             Test(Style.Bold | Style.Italic, "3");
             Test("\u94b1\u4e0d\u591f!", "\"\u94b1\u4e0d\u591f!\"");
+            Test("\u94b1\u4e0d\u591f!", "\"\\u94b1\\u4e0d\\u591f!\"");
         }
 
         static void ArrayTest<T>(T[] expected, string json)


### PR DESCRIPTION
Instead of grabbing the member attributes by using GetCustomAttribute(s) it now does a check with IsDefined first. This is an allocation free call, making the allocation costs go way down (tested with Unity profiler). It is also faster.

Other allocation helper is that I pre-set the capacity of the stringbuilder used when parsing string data, making it not having to reallocate the backing buffer as it grows.

I also merged in the ideas from your commit on making it build in Unity. I'm also using it in Unity, but on the latest version running the .NET 4.x Equivalent profile where it didn't complain. I now tested it using .NET 3.5 Equivalent profile. However, I don't ask for the whole attribute array, but rather do the call to get the one single attribute.

I also added a few tiny tests to cover the case of enums being a number in a string. My previous code tried to make it into a pure int, but I guess the simplification where it is packaged in a string is probably better since it is more consistent.