### PR TITLE
decimal type was missing from serializer

### DIFF
--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -59,6 +59,9 @@ namespace TinyJson
             {
                 stringBuilder.Append(((double)item).ToString(System.Globalization.CultureInfo.InvariantCulture));
             }
+            else if (type == typeof (decimal)) {
+                stringBuilder.Append (((decimal)item).ToString (System.Globalization.CultureInfo.InvariantCulture));
+            }
             else if (type == typeof(bool))
             {
                 stringBuilder.Append(((bool)item) ? "true" : "false");


### PR DESCRIPTION
oddly your tests already seem to check decimal serialization, but had some other tests using your serializer that failed w/decimals.   Then noticed there was no decimal handling in your writer.  

Works w/this patch, thanks for your hard work