### PR TITLE
Added support for all C# primitives.

### DIFF
--- a/src/JSONWriter.cs
+++ b/src/JSONWriter.cs
@@ -29,10 +29,10 @@ namespace TinyJson
             }
 
             Type type = item.GetType();
-            if (type == typeof(string))
+            if (type == typeof(string) || type == typeof(char))
             {
                 stringBuilder.Append('"');
-                string str = (string)item;
+                string str = item.ToString();
                 for (int i = 0; i<str.Length; ++i)
                     if (str[i] < ' ' || str[i] == '"' || str[i] == '\\')
                     {
@@ -47,7 +47,19 @@ namespace TinyJson
                         stringBuilder.Append(str[i]);
                 stringBuilder.Append('"');
             }
-            else if (type == typeof(byte) || type == typeof(int))
+            else if (type == typeof(byte) || type == typeof(sbyte))
+            {
+                stringBuilder.Append(item.ToString());
+            }
+            else if (type == typeof(short) || type == typeof(ushort))
+            {
+                stringBuilder.Append(item.ToString());
+            }
+            else if (type == typeof(int) || type == typeof(uint))
+            {
+                stringBuilder.Append(item.ToString());
+            }
+            else if (type == typeof(long) || type == typeof(ulong))
             {
                 stringBuilder.Append(item.ToString());
             }

--- a/test/TestWriter.cs
+++ b/test/TestWriter.cs
@@ -155,5 +155,45 @@ namespace TinyJson.Test
             Assert.AreEqual("{\"Colors\":\"Blue\",\"Style\":\"Underline\"}", new EnumClass { Colors = (Color)2, Style = (Style)4 }.ToJson());
             Assert.AreEqual("{\"Colors\":\"10\",\"Style\":\"17\"}", new EnumClass { Colors = (Color)10, Style = (Style)17 }.ToJson());
         }
+
+        public class PrimitiveObject
+        {
+            public bool Bool;
+            public byte Byte;
+            public sbyte SByte;
+            public short Short;
+            public ushort UShort;
+            public int Int;
+            public uint UInt;
+            public long Long;
+            public ulong ULong;
+            public char Char;
+            public float Single;
+            public double Double;
+            public decimal Decimal;
+        }
+
+        [TestMethod]
+        public void TestPrimitives()
+        {
+            Assert.AreEqual(
+                "{\"Bool\":true,\"Byte\":17,\"SByte\":-17,\"Short\":-123,\"UShort\":123,\"Int\":-56,\"UInt\":56,\"Long\":-34,\"ULong\":34,\"Char\":\"C\",\"Single\":4.3,\"Double\":5.6,\"Decimal\":10.1}",
+                new PrimitiveObject
+                {
+                    Bool = true,
+                    Byte = 17,
+                    SByte = -17,
+                    Short = -123,
+                    UShort = 123,
+                    Int = -56,
+                    UInt = 56,
+                    Long = -34,
+                    ULong = 34,
+                    Char = 'C',
+                    Single = 4.3f,
+                    Double = 5.6,
+                    Decimal = 10.1M
+                }.ToJson());
+        }
     }
 }


### PR DESCRIPTION
TinyJson is missing support for a handful of [C# primitive types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types) including: `char`, `sbyte`, `short`, `ushort`, `long`, and `ulong`. This PR contains writer support for all of them as well as a unit test that tests each primitive.